### PR TITLE
Add CI to test and deliver gem

### DIFF
--- a/.github/actions/deliver.sh
+++ b/.github/actions/deliver.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+export GEM_VERSION=${GITHUB_REF#refs/*/v}
+echo "Building gem ${GEM_VERSION}"
+gem build mapotempo_rubocop.gemspec
+
+status_code=$(curl  -s -o /dev/null -w "%{http_code}" --data-binary my_gem-${GEM_VERSION}.gem -H "Authorization:${RUBYGEM_API}" 'https://rubygems.org/api/v1/gems')
+
+if [ "${status_code}" != "200" ]; then
+  echo "Error delivering the gem to rubygems.org (status ${status_code})."
+  exit 1
+fi

--- a/.github/actions/post-build.sh
+++ b/.github/actions/post-build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+gem install ./mapotempo_rubocop-0.0.0.gem
+echo "require 'mapotempo_rubocop'" | irb

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -1,0 +1,38 @@
+name: Deliver CI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.5
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake test
+      - name: Build
+        run: gem build mapotempo_rubocop.gemspec
+        shell: bash
+      - name: Post build
+        run: ./.github/actions/post-build.sh
+        shell: bash
+  deliver:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      RUBYGEM_API: ${{ secrets.RUBYGEM_API }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Deliver
+        run: ./.github/actions/deliver.sh
+        shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: Main CI
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - 'v*.*.*'
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.5
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake test
+      - name: Build
+        run: gem build mapotempo_rubocop.gemspec
+        shell: bash
+      - name: Post build
+        run: ./.github/actions/post-build.sh
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.byebug_history

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+mapotempo_rubocop-*.gem
 .byebug_history

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
----
-language: ruby
-cache: bundler
-rvm:
-  - 2.4.0
-before_install: gem install bundler -v 2.1.4

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,12 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in mapotempo_rubocop.gemspec
 gemspec
+
+group :test do
+  gem 'byebug'
+  gem 'minitest'
+  gem 'minitest-focus'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mapotempo_rubocop (0.1.0)
+    mapotempo_rubocop (0.0.0)
       rubocop (~> 0.81.0)
       rubocop-minitest (~> 0.8.1)
       rubocop-performance (~> 1.5.2)
@@ -10,7 +10,11 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.1)
+    byebug (11.1.3)
     jaro_winkler (1.5.4)
+    minitest (5.14.2)
+    minitest-focus (1.2.1)
+      minitest (>= 4, < 6)
     parallel (1.19.2)
     parser (2.7.1.5)
       ast (~> 2.4.1)
@@ -37,7 +41,10 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.17.3)
+  byebug
   mapotempo_rubocop!
+  minitest
+  minitest-focus
   rake (~> 10.0)
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,12 @@
-require "bundler/gem_tasks"
-require "rake/testtask"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"]
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
 end
 
-task :default => :test
+task default: :test

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require "bundler/setup"
-require "mapotempo_rubocop"
+require 'bundler/setup'
+require 'mapotempo_rubocop'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +11,5 @@ require "mapotempo_rubocop"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start(__FILE__)

--- a/lib/mapotempo_rubocop.rb
+++ b/lib/mapotempo_rubocop.rb
@@ -1,4 +1,6 @@
-require "mapotempo_rubocop/version"
+# frozen_string_literal: true
+
+require 'mapotempo_rubocop/version'
 
 module MapotempoRubocop
   class Error < StandardError; end

--- a/lib/mapotempo_rubocop/version.rb
+++ b/lib/mapotempo_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MapotempoRubocop
-  VERSION = '0.1.0'
+  VERSION = ENV['GEM_VERSION'] || '0.0.0'
 end

--- a/lib/mapotempo_rubocop/version.rb
+++ b/lib/mapotempo_rubocop/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module MapotempoRubocop
-  VERSION = "0.1.0"
+  VERSION = '0.1.0'
 end

--- a/mapotempo_rubocop.gemspec
+++ b/mapotempo_rubocop.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'https://mapotempo.com'
   spec.summary     = 'Mapotempo rubocop'
   spec.description = 'Rubocop rules in mapotempo projects.'
-  spec.license     = 'AGPL-3.0-or-later'
+  spec.license     = 'MIT'
 
   spec.files = Dir['{app,config,db,lib}/**/*', 'LICENSE', 'Rakefile', 'README.md']
   spec.test_files = Dir['test/**/*']

--- a/mapotempo_rubocop.gemspec
+++ b/mapotempo_rubocop.gemspec
@@ -1,28 +1,28 @@
-$:.push File.expand_path("../lib", __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
 # Maintain your gem's version:
 require_relative 'lib/mapotempo_rubocop/version'
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |spec|
-  spec.name        = "mapotempo_rubocop"
+  spec.name        = 'mapotempo_rubocop'
   spec.version     = MapotempoRubocop::VERSION
-  spec.authors     = ["Valentin Le Guennec", "Yann Grégoire"]
+  spec.authors     = ['Valentin Le Guennec', 'Yann Grégoire']
   spec.email       = %w[val.leguennec@gmail.com yann@mapotempo.com]
-  spec.homepage    = "https://mapotempo.com"
-  spec.summary     = "Mapotempo rubocop"
-  spec.description = "Rubocop rules in mapotempo projects."
-  spec.license     = "AGPL"
+  spec.homepage    = 'https://mapotempo.com'
+  spec.summary     = 'Mapotempo rubocop'
+  spec.description = 'Rubocop rules in mapotempo projects.'
+  spec.license     = 'AGPL-3.0-or-later'
 
-  spec.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
-  spec.test_files = Dir["test/**/*"]
-
+  spec.files = Dir['{app,config,db,lib}/**/*', 'LICENSE', 'Rakefile', 'README.md']
+  spec.test_files = Dir['test/**/*']
 
   spec.add_dependency 'rubocop', '~> 0.81.0'
-  spec.add_dependency 'rubocop-performance', '~> 1.5.2'
   spec.add_dependency 'rubocop-minitest', '~> 0.8.1'
+  spec.add_dependency 'rubocop-performance', '~> 1.5.2'
 
   spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'rake', '~> 10.0'
-
 end

--- a/test/mapotempo_rubocop_test.rb
+++ b/test/mapotempo_rubocop_test.rb
@@ -1,11 +1,18 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class MapotempoRubocopTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::MapotempoRubocop::VERSION
   end
 
-  def test_it_does_something_useful
-    assert false
+  def test_config_is_correct
+    parallel = ENV['RUBOCOP_PARALLEL'] || ENV['CI'] ? '--parallel' : nil
+    # parallel option could cause not to use rubocop from bundle
+    options = "#{parallel} -f c --config .rubocop.yml --fail-level E --display-only-fail-level-offenses"
+    cmd = "bundle exec rubocop ./* #{options}"
+    o = system(cmd, [:out, :err] => '/dev/null')
+    assert o, "New Rubocop offenses added to the project, run: #{cmd}"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,8 @@
-$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
-require "mapotempo_rubocop"
+# frozen_string_literal: true
 
-require "minitest/autorun"
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'mapotempo_rubocop'
+
+require 'minitest/autorun'
+require 'byebug'
+require 'minitest/focus'


### PR DESCRIPTION
This PR set tests to the projects validating the rubocop configuration has no error, tests the installation of the gem into a project and deliver a gem versioned with the git tag to RubyGems (show [deliver flow](https://github.com/alain-andre/mapotempo_rubocop/actions/runs/763948656)). And [here](https://github.com/alain-andre/mapotempo_rubocop/actions/runs/764040685) is an exemple of how it is tested every times someone push or make a PR.

I have no access to this repo settings so I couldn't set the required variables to push to RubyGems. 